### PR TITLE
Add multiline theme

### DIFF
--- a/eshell-git-prompt.el
+++ b/eshell-git-prompt.el
@@ -73,6 +73,9 @@
     (powerline
      eshell-git-prompt-powerline
      eshell-git-prompt-powerline-regexp)
+    (multiline
+     eshell-git-prompt-multiline
+     eshell-git-prompt-multiline-regexp)
     ;; Only a single $
     (simple
      eshell-git-prompt-simple
@@ -499,6 +502,32 @@ It looks like:
      (propertize "$" 'invisible t) " ")))
 
 (defconst eshell-git-prompt-powerline-regexp "^[^$\n]*\\\$ ")
+
+(defun eshell-git-prompt-multiline ()
+  (let (separator hr dir git time prompt git-dirty)
+    (setq separator (with-face " | " :foreground "DimGray"))
+    (setq hr (with-face (concat "\n" (make-string (/ (window-total-width) 2) ?─) "\n") :foreground "DimGray") )
+    (setq dir
+          (concat
+           (with-face "🗀" :foreground "cyan1")
+           (with-face (concat  (abbreviate-file-name (eshell/pwd))))))
+    (setq git
+          (concat (with-face "⎇" :foreground "SpringGreen1")
+                  (with-face (concat (eshell-git-prompt--branch-name)))))
+    (setq git-dirty
+          (when (eshell-git-prompt--branch-name)
+            (if (eshell-git-prompt--collect-status)
+                (with-face " ✗" 'eshell-git-prompt-robyrussell-git-dirty-face)
+              (with-face " ✔" :foreground "green"))))
+    (setq time (with-face (format-time-string "%I:%M:%S %p") :foreground "#5a5b7f"))
+    (setq prompt (if (= (user-uid) 0)
+                     (with-face "\n#" :foreground "red2")
+                   (with-face "\nλ" :foreground "DarkOliveGreen3")))
+    (setq command (with-face " " :foreground "gold1"))
+
+    (concat hr dir separator git git-dirty separator time prompt)))
+
+(defconst eshell-git-prompt-multiline-regexp "^[^λ\n]*λ ")
 
 (defvar eshell-git-prompt-current-theme nil)
 

--- a/eshell-git-prompt.el
+++ b/eshell-git-prompt.el
@@ -165,7 +165,8 @@ You can add your own theme to this list, then run
   :group 'eshell-faces)
 
 (defface eshell-git-prompt-multiline-command-face
-  '((t :foreground "gold3"))
+  '((((class color) (background light)) :foreground "slate blue")
+    (((class color) (background  dark)) :foreground "gold"))
   "Face for command user typed in eshell git prompt theme `multiline`."
   :group 'eshell-faces)
 
@@ -546,7 +547,7 @@ It looks like:
     ;; Build prompt
     (concat hr dir separator git git-dirty separator time sign command)))
 
-(defconst eshell-git-prompt-multiline-regexp "^[^λ\n]*λ ")
+(defconst eshell-git-prompt-multiline-regexp "^[^$\n]*λ ")
 
 (defvar eshell-git-prompt-current-theme nil)
 

--- a/eshell-git-prompt.el
+++ b/eshell-git-prompt.el
@@ -159,13 +159,19 @@ You can add your own theme to this list, then run
   :group 'eshell-faces)
 
 (defface eshell-git-prompt-multiline-secondary-face
-  '((t :foreground "dim gray"))
+  '((((class color) (background light)) :foreground "light gray")
+    (((class color) (background  dark)) :foreground "dim gray"))
   "Face for secondary part in eshell git prompt theme `multiline`. e.g. separator, horizontal line, date."
   :group 'eshell-faces)
 
 (defface eshell-git-prompt-multiline-command-face
-  '((t :foreground "gold1"))
+  '((t :foreground "gold3"))
   "Face for command user typed in eshell git prompt theme `multiline`."
+  :group 'eshell-faces)
+
+(defface eshell-git-prompt-multiline-sign-face
+  '((t :foreground "deep pink"))
+  "Face for prompt sign in eshell git prompt theme `multiline`."
   :group 'eshell-faces)
 
 
@@ -533,8 +539,8 @@ It looks like:
     (setq time (with-face (format-time-string "%I:%M:%S %p") 'eshell-git-prompt-multiline-secondary-face))
     (setq sign
           (if (= (user-uid) 0)
-              "\n#"
-            "\nλ"))
+              (with-face "\n#" 'eshell-git-prompt-multiline-sign-face)
+            (with-face "\nλ" 'eshell-git-prompt-multiline-sign-face)))
     (setq command (with-face " " 'eshell-git-prompt-multiline-command-face))
 
     ;; Build prompt

--- a/eshell-git-prompt.el
+++ b/eshell-git-prompt.el
@@ -158,6 +158,16 @@ You can add your own theme to this list, then run
   "Face for git branch (not clean) in eshell git prompt theme `powerline`"
   :group 'eshell-faces)
 
+(defface eshell-git-prompt-multiline-secondary-face
+  '((t :foreground "dim gray"))
+  "Face for secondary part in eshell git prompt theme `multiline`. e.g. separator, horizontal line, date."
+  :group 'eshell-faces)
+
+(defface eshell-git-prompt-multiline-command-face
+  '((t :foreground "gold1"))
+  "Face for command user typed in eshell git prompt theme `multiline`."
+  :group 'eshell-faces)
+
 
 ;;; * Internal
 
@@ -504,28 +514,31 @@ It looks like:
 (defconst eshell-git-prompt-powerline-regexp "^[^$\n]*\\\$ ")
 
 (defun eshell-git-prompt-multiline ()
-  (let (separator hr dir git time prompt git-dirty)
-    (setq separator (with-face " | " :foreground "DimGray"))
-    (setq hr (with-face (concat "\n" (make-string (/ (window-total-width) 2) ?─) "\n") :foreground "DimGray") )
+  "Eshell Git prompt inspired by spaceship-prompt."
+  (let (separator hr dir git git-dirty time sign command)
+    (setq separator (with-face " | " 'eshell-git-prompt-multiline-secondary-face))
+    (setq hr (with-face (concat "\n" (make-string (/ (window-total-width) 2) ?─) "\n") 'eshell-git-prompt-multiline-secondary-face))
     (setq dir
           (concat
-           (with-face "🗀" :foreground "cyan1")
-           (with-face (concat  (abbreviate-file-name (eshell/pwd))))))
+           (with-face "🗀" 'eshell-git-prompt-directory-face)
+           (concat  (abbreviate-file-name (eshell/pwd)))))
     (setq git
-          (concat (with-face "⎇" :foreground "SpringGreen1")
-                  (with-face (concat (eshell-git-prompt--branch-name)))))
+          (concat (with-face "⎇" 'eshell-git-prompt-exit-success-face)
+                  (concat (eshell-git-prompt--branch-name))))
     (setq git-dirty
           (when (eshell-git-prompt--branch-name)
             (if (eshell-git-prompt--collect-status)
-                (with-face " ✗" 'eshell-git-prompt-robyrussell-git-dirty-face)
-              (with-face " ✔" :foreground "green"))))
-    (setq time (with-face (format-time-string "%I:%M:%S %p") :foreground "#5a5b7f"))
-    (setq prompt (if (= (user-uid) 0)
-                     (with-face "\n#" :foreground "red2")
-                   (with-face "\nλ" :foreground "DarkOliveGreen3")))
-    (setq command (with-face " " :foreground "gold1"))
+                (with-face " ✎" 'eshell-git-prompt-modified-face)
+              (with-face " ✔" 'eshell-git-prompt-exit-success-face))))
+    (setq time (with-face (format-time-string "%I:%M:%S %p") 'eshell-git-prompt-multiline-secondary-face))
+    (setq sign
+          (if (= (user-uid) 0)
+              "\n#"
+            "\nλ"))
+    (setq command (with-face " " 'eshell-git-prompt-multiline-command-face))
 
-    (concat hr dir separator git git-dirty separator time prompt)))
+    ;; Build prompt
+    (concat hr dir separator git git-dirty separator time sign command)))
 
 (defconst eshell-git-prompt-multiline-regexp "^[^λ\n]*λ ")
 


### PR DESCRIPTION
Hi👋
Thank you for the cool package!

I added the new multiline theme inspired by [spaceship\-prompt/spaceship\-prompt](https://github.com/spaceship-prompt/spaceship-prompt).

### light theme
![Screenshot_2021-08-16_23-05-59](https://user-images.githubusercontent.com/11595790/129583955-f522325d-5cfe-4561-b475-602b4c58a52a.png)

### dark theme
![Screenshot_2021-08-16_23-06-37](https://user-images.githubusercontent.com/11595790/129583961-de44d81d-6414-4fb9-bc6b-5ef299be3005.png)

### use-theme
My concern is that the addition of this theme will make the `use-theme` look worse.
I have not been able to solve this problem successfully...

![Screenshot_2021-08-17_00-00-14](https://user-images.githubusercontent.com/11595790/129585223-c96a2d29-d8f6-4668-830b-fe07216019ce.png)